### PR TITLE
Added empty Navigation Bar to left side of webpage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
-<script setup lang="ts">
+<script lang="ts" setup>
 import { ref, computed } from "vue";
-import type { DefineComponent, Ref } from 'vue';
+import type { DefineComponent, Ref } from "vue";
+import Navbar from "./components/Navbar.vue";
 import NotFound from "./routes/_NotFound.vue";
 // MAIN PAGES
 import Home from "./routes/Home.vue";
@@ -11,7 +12,7 @@ const routes: { [key: string]: DefineComponent<{}, {}, any> } = {
   "/about": About,
 };
 
-const currentPath : Ref<string> = ref(window.location.hash);
+const currentPath: Ref<string> = ref(window.location.hash);
 
 window.addEventListener("hashchange", () => {
   currentPath.value = window.location.hash;
@@ -23,8 +24,11 @@ const currentView = computed(() => {
 </script>
 
 <template>
-  <a href="#/">Home</a> |
-  <a href="#/about">About</a> |
-  <a href="#/non-existent-path">Broken Link</a>
-  <component :is="currentView" />
+  <Navbar />
+  <div id="content-area">
+    <a href="#/">Home</a> |
+    <a href="#/about">About</a> |
+    <a href="#/non-existent-path">Broken Link</a>
+    <component :is="currentView" />
+  </div>
 </template>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -31,7 +31,7 @@
     border-style: none;
     border-right-style: solid;
     border-width: var(--border-width);
-    border-color: $nord2;
+    border-color: var(--border-color);
 
     box-sizing: content-box;
   }
@@ -96,7 +96,7 @@
       width: 100%;
 
       border-radius: inherit;
-      outline: solid var(--border-width) $nord2;
+      outline: solid var(--border-width) var(--border-color);
       box-shadow: 0px 0px 0px 100px $nord1;
 
       clip-path: inset(

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,0 +1,111 @@
+<script lang="ts" setup></script>
+
+<template>
+  <div id="navbar">
+    <div id="nav-upper"></div>
+    <div id="nav-center"></div>
+    <div id="nav-lower"></div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "node_modules/nord/src/sass/nord.scss";
+
+#navbar {
+  --angle: 22deg;
+
+  position: relative;
+  height: 100%;
+  width: 100px;
+  margin-right: var(--border-width);
+
+  display: flex;
+  flex-direction: column;
+
+  #nav-upper,
+  #nav-lower {
+    position: relative;
+    width: 100%;
+
+    background-color: $nord1;
+    border-style: none;
+    border-right-style: solid;
+    border-width: var(--border-width);
+    border-color: $nord2;
+
+    box-sizing: content-box;
+  }
+
+  @mixin angled-pseudo-wedges($pos-offset, $angle-mult) {
+    content: "";
+
+    position: absolute;
+    height: calc(2 * var(--border-radius));
+    width: calc((100% - 2.5rem) / cos(var(--angle)));
+
+    #{$pos-offset}: calc(-1 * var(--border-width));
+    right: var(--inner-radius);
+
+    transform-origin: 100% var(--border-radius);
+    transform: rotate(calc($angle-mult * max(min(var(--angle), 90deg), 0deg)));
+
+    background-color: inherit;
+    border-style: none;
+    #{"border-" + $pos-offset + "-style"}: solid;
+    border-width: inherit;
+    border-color: inherit;
+  }
+
+  #nav-upper {
+    aspect-ratio: 1;
+
+    border-bottom-style: solid;
+    border-bottom-right-radius: var(--border-radius);
+
+    &:after {
+      @include angled-pseudo-wedges(bottom, -1);
+    }
+  }
+  #nav-lower {
+    flex: 1;
+
+    border-top-style: solid;
+    border-top-right-radius: var(--border-radius);
+
+    &:before {
+      @include angled-pseudo-wedges(top, 1);
+    }
+  }
+  #nav-center {
+    position: relative;
+    width: calc(2 * var(--inner-radius));
+    min-height: calc(2 * var(--inner-radius));
+    margin-block: calc(2 * var(--border-radius) * (1 / cos(var(--angle)) - 1) - 1px);
+
+    align-self: flex-end;
+
+    border-radius: var(--inner-radius);
+
+    z-index: 1;
+
+    &:before {
+      content: "";
+
+      position: absolute;
+      height: 100%;
+      width: 100%;
+
+      border-radius: inherit;
+      outline: solid var(--border-width) $nord2;
+      box-shadow: 0px 0px 0px 100px $nord1;
+
+      clip-path: inset(
+        calc(-2 * var(--border-radius) * (1 / cos(var(--angle)) - 1) - var(--border-width))
+        calc(50% + var(--inner-radius) * sin(var(--angle)))
+        calc(-2 * var(--border-radius) * (1 / cos(var(--angle)) - 1) - var(--border-width))
+        -100px
+      );
+    }
+  }
+}
+</style>

--- a/src/global.scss
+++ b/src/global.scss
@@ -4,19 +4,34 @@
 @import "node_modules/nord/src/sass/nord.scss";
 
 :root {
+  --border-width: 0.5rem;
+  --border-radius: 3rem;
+
   font-family: "Comfortaa", sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  background-color: $nord0;
   color: $nord6;
-  border-style: none;
-  border-width: 2rem;
-  border-color: $nord3;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+
+  --inner-radius: calc(var(--border-radius) - var(--border-width));
+}
+
+#app {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+
+  display: flex;
+
+  background-color: $nord0;
+
+  #content-area {
+    padding: calc(2 * var(--border-width));
+  }
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -6,6 +6,7 @@
 :root {
   --border-width: 0.4rem;
   --border-radius: 3rem;
+  --border-color: #{$nord2};
 
   font-family: "Comfortaa", sans-serif;
   line-height: 1.5;

--- a/src/global.scss
+++ b/src/global.scss
@@ -4,7 +4,7 @@
 @import "node_modules/nord/src/sass/nord.scss";
 
 :root {
-  --border-width: 0.5rem;
+  --border-width: 0.4rem;
   --border-radius: 3rem;
 
   font-family: "Comfortaa", sans-serif;


### PR DESCRIPTION
# Current View
![image](https://github.com/codedintellect/blunder-web/assets/67015559/fc77ad3a-89f5-4b31-931e-f9bb260a74b4)

## Allocating 3 slots for icons in indent
![image](https://github.com/codedintellect/blunder-web/assets/67015559/a4735317-14e6-4a00-8693-034eb78f4d57)

## Style logic breakdown
![indent-breakdown](https://github.com/codedintellect/blunder-web/assets/67015559/f60dbee5-0fff-4699-addc-1f410770a3ac)

 - In Yellow: Container for various selection icons
 - In Red: Box shadow of the "before" pseudo-element with "clip-path" applied
 - In Orange: Outline of previously mentioned pseudo-element
 - In Green: The "after" and "before" pseudo-element respectively with a border to create the flat angled part of the indent